### PR TITLE
fix: impact of change in GitHub token pattern

### DIFF
--- a/env/parameters.tmpl.schema.json
+++ b/env/parameters.tmpl.schema.json
@@ -52,7 +52,7 @@
           "description": "A token for the Git user that will perform git operations inside a pipeline. This includes environment repository creation, and so this token should have full repository permissions. To create a token go to {{ .GitServer }}/settings/tokens/new?scopes=repo,read:user,read:org,user:email,write:repo_hook,delete_repo then enter a name, click Generate token, and copy and paste the token into this prompt.",
           "minLength": 40,
           "maxLength": 40,
-          "pattern": "^[0-9a-f]{40}$"
+          "pattern": "^[0-9a-zA-Z_]{40}$"
         }
 {{- else if eq .GitKind "bitbucketserver" }}
         "token": {


### PR DESCRIPTION
As per https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/ the GitHub Tokens pattern has changed from [a-f0-9] to [A-Za-z0-9_], length remaining the same. This change was impacting the deployment using jx on GKE.